### PR TITLE
Depend on standalone PropTypes rather than React.PropTypes

### DIFF
--- a/lib/Touchable.js
+++ b/lib/Touchable.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import {
     PanResponder,
     View,
@@ -119,12 +121,12 @@ class Touchable extends React.Component {
 
 Touchable.propTypes = {
     style: View.propTypes.style,
-    activeOpacity: React.PropTypes.number,
-    underlayColor: React.PropTypes.string,
-    onPressIn: React.PropTypes.func,
-    onPress: React.PropTypes.func,
-    onPressOut: React.PropTypes.func,
-    onLongPress: React.PropTypes.func
+    activeOpacity: PropTypes.number,
+    underlayColor: PropTypes.string,
+    onPressIn: PropTypes.func,
+    onPress: PropTypes.func,
+    onPressOut: PropTypes.func,
+    onLongPress: PropTypes.func
 };
 
 Touchable.defaultProps = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import {
     StyleSheet,
     Text,
@@ -305,32 +307,32 @@ class Swipeout extends React.Component {
 
 Swipeout.propTypes = {
     style: View.propTypes.style,
-    left: React.PropTypes.oneOfType([
-        React.PropTypes.object,
-        React.PropTypes.array
+    left: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array
     ]),
-    right: React.PropTypes.oneOfType([
-        React.PropTypes.object,
-        React.PropTypes.array
+    right: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array
     ]),
-    snapVelocity: React.PropTypes.number,
-    optionWidth: React.PropTypes.number,
-    actionThreshold: React.PropTypes.number,
-    useNativeDriver: React.PropTypes.bool,
-    onPress: React.PropTypes.func,
-    onPressIn: React.PropTypes.func,
-    onPressOut: React.PropTypes.func,
-    onLongPress: React.PropTypes.func,
-    onOpen: React.PropTypes.func,
-    onClose: React.PropTypes.func,
-    underlayColor: React.PropTypes.string,
-    activeOpacity: React.PropTypes.number,
+    snapVelocity: PropTypes.number,
+    optionWidth: PropTypes.number,
+    actionThreshold: PropTypes.number,
+    useNativeDriver: PropTypes.bool,
+    onPress: PropTypes.func,
+    onPressIn: PropTypes.func,
+    onPressOut: PropTypes.func,
+    onLongPress: PropTypes.func,
+    onOpen: PropTypes.func,
+    onClose: PropTypes.func,
+    underlayColor: PropTypes.string,
+    activeOpacity: PropTypes.number,
 
     /**
      * unopen
      */
-    leftActionThreshold: React.PropTypes.number,
-    rightActionThreshold: React.PropTypes.number,
+    leftActionThreshold: PropTypes.number,
+    rightActionThreshold: PropTypes.number,
 };
 
 Swipeout.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-swipe-out",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The iOS-style Swipeout component, implement with javascript, running on iOS and Android. High performance, interactive, and configurable.",
   "keywords": [
     "swipeout",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/SmallComfort/rn-swipe-out.git"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
Allows this project to work with react-native v0.48+ 